### PR TITLE
Add gulp-file-include for HTML partials

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,6 +5,7 @@ const postcss       = require( 'gulp-postcss' );
 const autoprefixer  = require( 'autoprefixer' );
 const sass          = require( 'gulp-sass' );
 const sassLint      = require( 'gulp-sass-lint' );
+const fileinclude   = require( 'gulp-file-include' );
 
 // Compile and minify CSS.
 gulp.task( 'styles', () => {
@@ -30,5 +31,15 @@ gulp.task( 'lint-sass', function () {
 	.pipe( sassLint.failOnError() )
 });
 
+// HTML file include
+gulp.task( 'fileinclude', function() {
+	gulp.src( ['./src/index.html'] )
+		.pipe( fileinclude( {
+			prefix:   '@',
+			basepath: '@file'
+		} ) )
+		.pipe( gulp.dest( './' ) );
+} );
+
 // Tasks
-gulp.task( 'default', [ 'styles' ] );
+gulp.task( 'default', [ 'styles', 'fileinclude' ] );

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "devDependencies": {
     "autoprefixer": "^6.3.6",
     "gulp": "^3.9.1",
+    "gulp-file-include": "^0.13.7",
     "gulp-postcss": "^6.1.1",
     "gulp-sass": "^2.3.2",
     "gulp-sass-lint": "^1.2.0",

--- a/src/components/h1.html
+++ b/src/components/h1.html
@@ -1,0 +1,1 @@
+<h1>Juniper. The Human Made Pattern Library.</h1>

--- a/src/components/h2.html
+++ b/src/components/h2.html
@@ -1,0 +1,1 @@
+<h2>Lorem ipsum dolor sit amet</h2>

--- a/src/components/p.html
+++ b/src/components/p.html
@@ -1,0 +1,1 @@
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam in dui mauris. Vivamus hendrerit arcu sed erat molestie vehicula. Sed auctor neque eu tellus rhoncus ut eleifend nibh porttitor. Ut in nulla enim. Phasellus molestie magna non est.</p>

--- a/src/index.html
+++ b/src/index.html
@@ -10,14 +10,13 @@
 
 <div class="container">
 
-	<h1>Juniper. The Human Made Pattern Library.</h1>
+	@include( './components/h1.html' )  
 
-	<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam in dui mauris. Vivamus hendrerit arcu sed erat molestie vehicula. Sed auctor neque eu tellus rhoncus ut eleifend nibh porttitor. Ut in nulla enim. Phasellus molestie magna non est.</p>
-	<p>Bibendum non venenatis nisl tempor. Suspendisse dictum feugiat nisl ut dapibus. Mauris iaculis porttitor posuere. Praesent id metus massa, ut blandit odio. Proin quis tortor orci. Etiam at risus et justo dignissim congue.</p>
+	@include( './components/p.html' )  
 
-	<h2>H2: Tempor, lacus lacus ornare ante.</h2>
-	<p>Ac egestas est urna sit amet arcu. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos.</p>
-	<p>Sed molestie augue sit amet leo consequat posuere. Vestibulum ante ipsum.</p>
+	@include( './components/h2.html' )  
+
+	@include( './components/p.html' )
 
 	<h3>H3: In libero.</h3>
 	<p>Donec congue lacinia dui, a porttitor lectus condimentum laoreet. Nunc eu ullamcorper orci. Quisque eget odio ac lectus vestibulum faucibus eget in metus. In pellentesque faucibus vestibulum. Nulla at nulla justo, eget luctus tortor. Nulla facilisi. Duis aliquet egestas purus in blandit. Curabitur vulputate, ligula lacinia scelerisque.</p>

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+	<title>Juniper - HM Pattern Library</title>
+	<link rel="stylesheet" href="/dist/styles/style.css" />
+</head>
+
+<body>
+
+<div class="container">
+
+	<h1>Juniper. The Human Made Pattern Library.</h1>
+
+	<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam in dui mauris. Vivamus hendrerit arcu sed erat molestie vehicula. Sed auctor neque eu tellus rhoncus ut eleifend nibh porttitor. Ut in nulla enim. Phasellus molestie magna non est.</p>
+	<p>Bibendum non venenatis nisl tempor. Suspendisse dictum feugiat nisl ut dapibus. Mauris iaculis porttitor posuere. Praesent id metus massa, ut blandit odio. Proin quis tortor orci. Etiam at risus et justo dignissim congue.</p>
+
+	<h2>H2: Tempor, lacus lacus ornare ante.</h2>
+	<p>Ac egestas est urna sit amet arcu. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos.</p>
+	<p>Sed molestie augue sit amet leo consequat posuere. Vestibulum ante ipsum.</p>
+
+	<h3>H3: In libero.</h3>
+	<p>Donec congue lacinia dui, a porttitor lectus condimentum laoreet. Nunc eu ullamcorper orci. Quisque eget odio ac lectus vestibulum faucibus eget in metus. In pellentesque faucibus vestibulum. Nulla at nulla justo, eget luctus tortor. Nulla facilisi. Duis aliquet egestas purus in blandit. Curabitur vulputate, ligula lacinia scelerisque.</p>
+	<p>Primis in faucibus orci luctus et ultrices posuere cubilia Curae; Proin vel ante a orci tempus eleifend ut et magna. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus luctus urna sed urna ultricies ac tempor dui sagittis.</p>
+
+	<h4>H4: Vestibulum mollis mauris enim.</h4>
+	<h5>H5: Morbi euismod magna ac lorem rutrum elementum.</h5>
+	<h6>H6: Donec viverra auctor lobortis.</h6>
+
+	<blockquote>Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa <strong>strong</strong>. Cum sociis natoque penatibus et magnis dis parturient montes, In <em>em</em> justo. Nullam <a href="#">link</a> dictum felis eu pede mollis pretium.</blockquote>
+
+	<ul>
+		<li>Pellentesque eu est a nulla placerat dignissim.</li>
+		<li>Morbi a enim in magna semper bibendum.</li>
+		<li>Etiam scelerisque, nunc ac egestas consequat, odio nibh euismod nulla, eget auctor orci nibh vel nisi.</li>
+	</ul>
+
+	<ol>
+		<li>Aliquam erat volutpat.</li>
+		<li>Mauris vel neque sit amet nunc gravida congue sed sit amet purus.</li>
+		<li>Quisque lacus quam, egestas ac tincidunt a, lacinia vel velit.</li>
+	</ol>
+
+	<p>Sed molestie augue sit amet leo consequat posuere. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Proin vel ante a orci tempus eleifend ut et magna. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus luctus urna sed urna ultricies ac tempor dui sagittis. In condimentum facilisis porta. Sed nec.</p>
+
+	<table class="data">
+		<tr>
+			<th>Entry Header 1</th>
+			<th>Entry Header 2</th>
+			<th>Entry Header 3</th>
+			<th>Entry Header 4</th>
+		</tr>
+		<tr>
+			<td>Entry First Line 1</td>
+			<td>Entry First Line 2</td>
+			<td>Entry First Line 3</td>
+			<td>Entry First Line 4</td>
+		</tr>
+		<tr>
+			<td>Entry Line 1</td>
+			<td>Entry Line 2</td>
+			<td>Entry Line 3</td>
+			<td>Entry Line 4</td>
+		</tr>
+		<tr>
+			<td>Entry Last Line 1</td>
+			<td>Entry Last Line 2</td>
+			<td>Entry Last Line 3</td>
+			<td>Entry Last Line 4</td>
+		</tr>
+	</table>
+
+</div>
+
+</body>
+
+</html>


### PR DESCRIPTION
The `index.html` file in the root is compiled from the `src/index.html` file, which uses the `gulp`file`include` task.

Includes are formatted `@include( 'file.html' )  `.

All HTML components are in `src/components`. Current ones contain dummy content.