### PR TITLE
Copy SASS to dist

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,7 +11,7 @@ const imagemin      = require( 'gulp-imagemin' );
 const uglify        = require( 'gulp-uglify' );
 const concat        = require( 'gulp-concat' );
 const rename        = require( 'gulp-rename' );
-const gulpCopy      = require('gulp-copy');
+const gulpCopy      = require( 'gulp-copy' );
 
 // Compile and minify CSS.
 gulp.task( 'styles', () => {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -25,7 +25,7 @@ gulp.task( 'styles', () => {
 		.pipe( sourcemaps.write('.') )
 		.pipe( gulp.dest( './dist/assets/styles' ) );
 
-	// Compile SASS to dist for use in other projects.
+	// Copy SASS to dist for use in other projects.
 	gulp.src( './src/styles/**/*.scss' )
 		.pipe( gulpCopy( './dist/assets/sass', { prefix: 2 } ) );
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,6 +11,7 @@ const imagemin      = require( 'gulp-imagemin' );
 const uglify        = require( 'gulp-uglify' );
 const concat        = require( 'gulp-concat' );
 const rename        = require( 'gulp-rename' );
+const gulpCopy      = require('gulp-copy');
 
 // Compile and minify CSS.
 gulp.task( 'styles', () => {
@@ -21,6 +22,9 @@ gulp.task( 'styles', () => {
 		.pipe( postcss( [ autoprefixer( { browsers: ['last 3 versions'] } ) ] ) )
 		.pipe( sourcemaps.write('.') )
 		.pipe( gulp.dest( './dist/assets/styles' ) );
+
+	gulp.src( './src/styles/**/*.scss' )
+		.pipe( gulpCopy( './dist/assets/sass', { prefix: 2 } ) );
 });
 
 // Watch for changes in JS/CSS.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,6 +15,8 @@ const gulpCopy      = require( 'gulp-copy' );
 
 // Compile and minify CSS.
 gulp.task( 'styles', () => {
+
+	// Compile SASS to CSS.
 	gulp.src( './src/styles/*.scss' )
 		.pipe( sourcemaps.init() )
 		.pipe( sass( { outputStyle: 'compressed' } )
@@ -23,6 +25,7 @@ gulp.task( 'styles', () => {
 		.pipe( sourcemaps.write('.') )
 		.pipe( gulp.dest( './dist/assets/styles' ) );
 
+	// Compile SASS to dist for use in other projects.
 	gulp.src( './src/styles/**/*.scss' )
 		.pipe( gulpCopy( './dist/assets/sass', { prefix: 2 } ) );
 });

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "autoprefixer": "^6.3.6",
     "gulp": "^3.9.1",
     "gulp-concat": "^2.6.0",
+    "gulp-copy": "0.0.2",
     "gulp-file-include": "^0.13.7",
     "gulp-imagemin": "^3.0.1",
     "gulp-newer": "^1.2.0",


### PR DESCRIPTION
We should include the SASS files in dist so that people can just grab dist and include it in their projects and still use the SASS.