### PR TITLE
Fix nav accordion button overlap

### DIFF
--- a/src/js/NavAccordion.js
+++ b/src/js/NavAccordion.js
@@ -36,7 +36,7 @@
 		} );
 
 		if ( anchor.length ) {
-			anchor[0].appendChild( navAccordionToggle );
+			anchor[0].insertBefore( navAccordionToggle, anchor[0].childNodes[0] );
 		}
 
 		var toggleSubNav = function( show ) {

--- a/src/styles/base/_typography.scss
+++ b/src/styles/base/_typography.scss
@@ -107,7 +107,7 @@ ol,
 
 ul,
 ol {
-	list-style-position: inside;
+	list-style-position: outside;
 	padding: 0;
 	padding: 0 0 0 $gutter-width;
 }

--- a/src/styles/base/_typography.scss
+++ b/src/styles/base/_typography.scss
@@ -152,7 +152,7 @@ pre {
 }
 
 pre {
-	padding: #{ $base-line-height * .5 } 15px;
+	padding: #{ $base-line-height * .5 } #{ $gutter-width / 2 };
 	display: block;
 	margin: #{ $base-line-height * .75 } 0;
 	max-width: 100%;

--- a/src/styles/components/_NavAccordion.scss
+++ b/src/styles/components/_NavAccordion.scss
@@ -133,10 +133,9 @@
 
 	@extend .Btn-Small;
 	display: block;
-	position: absolute;
-	right: 0;
-	top: 0;
-	margin: 0;
+	position: relative;
+	float: right;
+	margin: #{ $base-line-height / -4 } 0;
 	padding: 0;
 	height: $base-line-height * 1.5;
 	width: $base-line-height * 1.5;

--- a/src/styles/vendor/_prismjs.scss
+++ b/src/styles/vendor/_prismjs.scss
@@ -30,7 +30,6 @@ pre[class*="language-"] {
 /* Code blocks */
 pre[class*="language-"] {
 	padding: #{ $base-line-height / 2 } #{ $gutter-width / 2 };
-	padding: #{ $base-line-height / 2 } 0;
 	overflow: auto;
 }
 


### PR DESCRIPTION
The toggle button was absolutely positioned, so links with long titles could overlap.

Better is to float right, so the text wraps around it. Only catch is the toggle needs to be prepended not appended - but I think thats fine.

Also snuck a couple of typography fixes in with this PR.