### PR TITLE
Split core JS and style guide JS

### DIFF
--- a/src/html/components/search.html
+++ b/src/html/components/search.html
@@ -9,13 +9,13 @@
 			<input class="SearchBar_Field" type="search" id="searchBar_Field" placeholder="Search the site&hellip;" />
 			<ul class="SearchBar_Results">
 				<li class="SearchBar_Result">
-					<a href="#">
+					<a href="http://hmn.md">
 						<h3 class="SearchBar_Result_Title">Test Search Result</h3>
 						<p class="SearchBar_Result_Text">Praesent id metus massa, ut blandit odio. Proin quis tortor orci. Etiam at risus et justo dignissim congue.</p>
 					</a>
 				</li>
 				<li class="SearchBar_Result">
-					<a href="#">
+					<a href="http://hmn.md">
 						<h3 class="SearchBar_Result_Title">Test Search Result</h3>
 						<p class="SearchBar_Result_Text">Suspendisse dictum feugiat nisl ut dapibus. Mauris iaculis porttitor posuere. Praesent id metus massa, ut blandit odio. Proin quis tortor orci. Etiam at risus et justo dignissim congue. Donec congue lacinia dui.</p>
 					</a>

--- a/src/html/components/search.html
+++ b/src/html/components/search.html
@@ -7,22 +7,20 @@
 
 		<div class="SearchBar_Container">
 			<input class="SearchBar_Field" type="search" id="searchBar_Field" placeholder="Search the site&hellip;" />
-			<div class="SearchBar_Results">
-				<ul class="SearchBar_Results">
-					<li class="SearchBar_Result">
-						<a href="#">
-							<h3 class="SearchBar_Result_Title">Test Search Result</h3>
-							<p class="SearchBar_Result_Text">Praesent id metus massa, ut blandit odio. Proin quis tortor orci. Etiam at risus et justo dignissim congue.</p>
-						</a>
-					</li>
-					<li class="SearchBar_Result">
-						<a href="#">
-							<h3 class="SearchBar_Result_Title">Test Search Result</h3>
-							<p class="SearchBar_Result_Text">Suspendisse dictum feugiat nisl ut dapibus. Mauris iaculis porttitor posuere. Praesent id metus massa, ut blandit odio. Proin quis tortor orci. Etiam at risus et justo dignissim congue. Donec congue lacinia dui.</p>
-						</a>
-					</li>
-				</ul>
-			</div>
+			<ul class="SearchBar_Results">
+				<li class="SearchBar_Result">
+					<a href="#">
+						<h3 class="SearchBar_Result_Title">Test Search Result</h3>
+						<p class="SearchBar_Result_Text">Praesent id metus massa, ut blandit odio. Proin quis tortor orci. Etiam at risus et justo dignissim congue.</p>
+					</a>
+				</li>
+				<li class="SearchBar_Result">
+					<a href="#">
+						<h3 class="SearchBar_Result_Title">Test Search Result</h3>
+						<p class="SearchBar_Result_Text">Suspendisse dictum feugiat nisl ut dapibus. Mauris iaculis porttitor posuere. Praesent id metus massa, ut blandit odio. Proin quis tortor orci. Etiam at risus et justo dignissim congue. Donec congue lacinia dui.</p>
+					</a>
+				</li>
+			</ul>
 
 			<button class="SearchBar_Submit">Submit</button>
 

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -16,30 +16,55 @@
 
 <body>
 
-<div class="container">
+	<div class="container">
 
-	<h1 class="pattern-library-title">Juniper.</h1>
-	<p class="pattern-library-subtitle">The Human Made Pattern Library.</p>
+		<h1 class="pattern-library-title">Juniper.</h1>
+		<p class="pattern-library-subtitle">The Human Made Pattern Library.</p>
 
-	@include( './components/body-text.html' )  
-	@include( './components/blockquote.html' )  
-	@include( './components/lists.html' )  
-	@include( './components/table.html' )  
-	@include( './components/headings.html' )  
-	@include( './components/colour-swatches.html' )  
-	@include( './components/logos.html' )  
-	@include( './components/code-block.html' )
-	@include( './components/buttons.html' )
-	@include( './components/forms.html' )
-	@include( './components/loading-indicators.html' )
-	@include( './components/search.html' )  
-	@include( './components/wordpress-images.html' )
-	@include( './components/wordpress-captions.html' )
-	@include( './components/nav-accordion.html' )
+		@include( './components/body-text.html' )  
+		@include( './components/blockquote.html' )  
+		@include( './components/lists.html' )  
+		@include( './components/table.html' )  
+		@include( './components/headings.html' )  
+		@include( './components/colour-swatches.html' )  
+		@include( './components/logos.html' )  
+		@include( './components/code-block.html' )
+		@include( './components/buttons.html' )
+		@include( './components/forms.html' )
+		@include( './components/loading-indicators.html' )
+		@include( './components/search.html' )  
+		@include( './components/wordpress-images.html' )
+		@include( './components/wordpress-captions.html' )
+		@include( './components/nav-accordion.html' )
 
-</div>
+	</div>
 
-<script src="./assets/js/app.min.js"></script>
+	<script src="./assets/js/app.min.js"></script>
+
+	<script>
+
+		(function() {
+
+			// Fake some search results for search bar demo.
+			Array.prototype.forEach.call( document.getElementsByClassName( 'SearchBar' ), function( searchBar ) {
+
+				var fields = searchBar.getElementsByClassName( 'SearchBar_Field' );
+
+				if ( fields.length > 0 ) {
+					fields[0].addEventListener( "keyup", function() {
+						if ( fields[0].value.length > 0 ) {
+							searchBar.classList.add( 'SearchBar-HasResults' );
+						} else {
+							searchBar.classList.remove( 'SearchBar-HasResults' );
+						}
+					} );
+				}
+
+			} );
+
+		} )();
+
+	</script>
 
 </body>
 

--- a/src/js/SearchBar.js
+++ b/src/js/SearchBar.js
@@ -18,7 +18,9 @@
 		} );
 
 		field.addEventListener( "blur", function() {
-			searchBar.classList.remove( 'SearchBar-Focused' );
+			window.setTimeout( function() {
+				searchBar.classList.remove( 'SearchBar-Focused' );
+			}, 500 )
 		} );
 
 	}

--- a/src/js/SearchBar.js
+++ b/src/js/SearchBar.js
@@ -21,13 +21,6 @@
 			searchBar.classList.remove( 'SearchBar-Focused' );
 		} );
 
-		field.addEventListener( "keyup", function() {
-			if ( field.value.length > 0 ) {
-				searchBar.classList.add( 'SearchBar-HasResults' );
-			} else {
-				searchBar.classList.remove( 'SearchBar-HasResults' );
-			}
-		} );
 	}
 
 })();

--- a/src/styles/components/_SearchBar.scss
+++ b/src/styles/components/_SearchBar.scss
@@ -91,6 +91,7 @@
 	color: #FFF;
 	margin: 0;
 	list-style: none;
+	z-index: 50;
 }
 
 .SearchBar_Result {


### PR DESCRIPTION
This JS relates ONLY to the style guide demo page, and should not be bundled with the released version. It should be up to whoever the implementation to handle this.

There's not much right now - so may aw well stick it in the footer. As/if it grows, we can maybe move into a separate file.