### PR TITLE
Fix bugs in tables.

### DIFF
--- a/src/styles/base/_tables.scss
+++ b/src/styles/base/_tables.scss
@@ -10,12 +10,14 @@ td {
 	padding: #{ $base-line-height / 3 } #{ $gutter-width / 2 };
 	border-bottom: 1px solid $border-color;
 	border-right: 1px solid $border-color;
+	vertical-align: top;
 
 	&:last-child {
 		border-right: none;
 	}
 }
 
+tbody:last-child > tr:last-child th,
 tbody:last-child > tr:last-child td {
 	border-bottom: none;
 }


### PR DESCRIPTION
- If a th is at the bottom, we're not removing the bottom border.
- Table content is centered vertically by default. Looks pretty odd. 