### PR TITLE
Fix form input placeholders not showing in MS Edge

### DIFF
--- a/src/styles/components/_Forms.scss
+++ b/src/styles/components/_Forms.scss
@@ -58,8 +58,8 @@ input[type="email"] {
 
 	&::placeholder {
 		font-style: italic;
-		color: inherit;
-		opacity: 0.5;
+		color: rgba( $color-input-text, .5 );
+		opacity: 1; // Required for MS Edge
 	}
 
 }

--- a/src/styles/components/_SearchBar.scss
+++ b/src/styles/components/_SearchBar.scss
@@ -37,10 +37,9 @@
 	padding-right: 0;
 	width: 100%;
 
-	::placeholder {
-		opacity: .75;
+	&::placeholder {
+		color: rgba( #FFF, .75 );
 	}
-
 }
 
 // TODO - remove in JS, replace with 'clear'?


### PR DESCRIPTION
Caused by opacity being set < 1 on the ::placeholder pseudo element, and any of the placeholder parent elements (including the actual input itself, right up to body) have position: relative or absolute applied.

Use RGBA colour instead.

See: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/3901363/
Codepen: http://codepen.io/sambulance/pen/XNKQag