### PR TITLE
New theme style updates.

### DIFF
--- a/assets/sass/_variables.scss
+++ b/assets/sass/_variables.scss
@@ -2,11 +2,12 @@
  * Base Settings
  */
 
-$margin-vertical-sm: 1.666666667rem !default;
-$margin-vertical-lg: 4.666666667rem !default;
+$margin-vertical-sm:  1.666666667rem !default;
+$margin-vertical-lg:  4.666666667rem !default;
 
-$base-line-height:   1.555rem !default; // 28px
-$base-font-size:     18px !default;
+$base-line-height:    1.555rem !default; // 28px
+$base-line-height-sm: 1.333rem !default; // 24px
+$base-font-size:      18px !default;
 
 $gutter-width: 15px !default;
 

--- a/assets/sass/_variables.scss
+++ b/assets/sass/_variables.scss
@@ -3,7 +3,7 @@
  */
 
 $margin-vertical-sm: 1.666666667rem !default;
-$margin-vertical-lg: 5.555555556rem !default;
+$margin-vertical-lg: 4.666666667rem !default;
 
 $base-line-height:   1.555rem !default; // 28px
 $base-font-size:     18px !default;

--- a/assets/sass/base/_typography-mixins.scss
+++ b/assets/sass/base/_typography-mixins.scss
@@ -1,9 +1,6 @@
 @mixin font-heading {
-
 	font-family: $font-family-heading;
 	font-weight: 700;
-	text-transform: uppercase;
-	letter-spacing: 0.02em;
 
 	em,
 	i,
@@ -35,17 +32,17 @@
 }
 
 @mixin text-xl {
-	font-size: 1.666666667rem;
+	font-size: 1.777777778rem;
 	line-height: $base-line-height * 1.5;
 }
 
 @mixin text-lg {
-	font-size: 1.555555556rem;
+	font-size: 1.333333333rem;
 	line-height: $base-line-height * 1.5;
 }
 
 @mixin text-md {
-	font-size: 1.333333333rem;
+	font-size: 1.111111111rem;
 	line-height: $base-line-height * 1.25;
 }
 

--- a/assets/sass/base/_typography-mixins.scss
+++ b/assets/sass/base/_typography-mixins.scss
@@ -27,13 +27,23 @@
 }
 
 @mixin text-xxl {
-	font-size: 2.777777778rem;
-	line-height: $base-line-height * 2.5;
+	font-size:  1.555555556rem;
+	line-height: $base-line-height-sm * 1.5;
+
+	@media #{ $mq-sm-up } {
+		font-size: 2.777777778rem;
+		line-height: $base-line-height-sm * 2.5;
+	}
 }
 
 @mixin text-xl {
-	font-size: 1.777777778rem;
-	line-height: $base-line-height * 1.5;
+	font-size:  1.333333333rem;
+	line-height: $base-line-height-sm * 1.25;
+
+	@media #{ $mq-sm-up } {
+		font-size: 1.777777778rem;
+		line-height: $base-line-height * 1.5;
+	}
 }
 
 @mixin text-lg {
@@ -47,8 +57,13 @@
 }
 
 @mixin text-std {
-	font-size: 1rem;
+	font-size: .888888889rem;
 	line-height: $base-line-height;
+
+	@media #{ $mq-sm-up } {
+		font-size: 1rem;
+		line-height: $base-line-height;
+	}
 }
 
 @mixin text-sm {

--- a/assets/sass/base/_typography.scss
+++ b/assets/sass/base/_typography.scss
@@ -28,6 +28,7 @@ h1,
 .text-xxl {
 	@include text-xxl;
 	@include font-heading;
+	text-transform: uppercase;
 	margin: $margin-vertical-sm 0;
 	color: $color-text-heading;
 }
@@ -43,7 +44,7 @@ h2,
 h3,
 .text-lg {
 	@include text-lg;
-	@include font-body;
+	@include font-heading;
 	margin: $margin-vertical-sm 0;
 	color: $color-text-heading;
 }
@@ -80,7 +81,7 @@ ol {
 
 blockquote {
 	@include text-lg;
-	margin: $margin-vertical-sm 0 $margin-vertical-sm;
+	margin: $margin-vertical-lg 0;
 }
 
 hr {

--- a/assets/sass/base/_typography.scss
+++ b/assets/sass/base/_typography.scss
@@ -39,6 +39,11 @@ h2,
 	@include font-heading;
 	margin: $margin-vertical-sm 0;
 	color: $color-text-heading;
+
+
+	@media #{ $mq-sm-down } {
+		text-transform: uppercase;
+	}
 }
 
 h3,
@@ -81,7 +86,11 @@ ol {
 
 blockquote {
 	@include text-lg;
-	margin: $margin-vertical-lg 0;
+	margin: $margin-vertical-sm 0;
+
+	@media #{ $mq-sm-up } {
+		margin: $margin-vertical-lg 0;
+	}
 }
 
 hr {

--- a/assets/sass/components/_wordpress-images.scss
+++ b/assets/sass/components/_wordpress-images.scss
@@ -28,7 +28,7 @@
 }
 
 .wp-caption {
-
+	max-width: 100%;
 	margin-top: 0;
 
 	img {
@@ -40,6 +40,7 @@
 .wp-caption-text {
 	@include text-sm;
 	color: $hm-medium-grey;
+	margin-top: 0;
 	padding: #{ $margin-vertical-sm / 4 } 0;
 }
 


### PR DESCRIPTION
I'm tweaking some typography and block spacing styles to match the designs in the new theme. Specifically, have been looking at styles from the default article page (https://zpl.io/Z1liyvC), which mainly includes different styles for headings, spacing around blockquotes, and spacing around image captions.

Here's a screenshot of the headings, note that I've bumped all styles up a level for semantic purposes.

<img width="846" alt="screen shot 2017-03-22 at 1 41 41 pm" src="https://cloud.githubusercontent.com/assets/801097/24215011/64037ca6-0f05-11e7-9c02-3547b89bc78e.png">


Basing this of of the `v2-release` branch since that seems to be where things currently stand in https://github.com/humanmade/Human-Made-Website-Theme/

