### PR TITLE
Redesign link and button tweaks

### DIFF
--- a/src/styles/base/_typography-mixins.scss
+++ b/src/styles/base/_typography-mixins.scss
@@ -51,6 +51,11 @@
 	line-height: $base-line-height * 1.5;
 }
 
+@mixin text-xm {
+	font-size: 1.222222222rem;
+	line-height: $base-line-height * 1.25;
+}
+
 @mixin text-md {
 	font-size: 1.111111111rem;
 	line-height: $base-line-height * 1.25;

--- a/src/styles/base/_typography-mixins.scss
+++ b/src/styles/base/_typography-mixins.scss
@@ -119,3 +119,17 @@
 	}
 
 }
+
+@mixin text-unlink {
+	color: inherit;
+	text-decoration: none;
+
+	&:hover,
+	&:focus {
+		text-decoration: underline;
+	}
+
+	&:focus {
+		outline: 1px solid rgba( $hm-dark-grey, .4 );
+	}
+}

--- a/src/styles/components/_Buttons.scss
+++ b/src/styles/components/_Buttons.scss
@@ -1,10 +1,9 @@
 .Btn {
-
 	@include font-body;
-	@include text-lg;
-	border: 2px solid $color-link;
+	@include text-xm;
+	border: 1px solid $color-link;
 	border-radius: 4px;
-	padding: 0 $gutter-width;
+	padding: #{ $gutter-width / 4 } $gutter-width;
 	background: none;
 	color: $color-link;
 	margin-bottom: $margin-vertical-sm / 2;
@@ -36,6 +35,11 @@
 		opacity: 0.3;
 	}
 
+	&--block {
+		width: 100%;
+		margin-bottom: $margin-vertical-sm;
+		margin-right: 0;
+	}
 }
 
 .Btn-Secondary {


### PR DESCRIPTION
This contains three small changes needed while working on the homepage layout. Specifically:

* a `text-unlink` mixin for making links that inherit the color of their containers—useful for links inside headers in a post list.
* a new text size mixin between `text-md` and `text-lg` that I named `text-xm` (i.e., extra medium) for lack of a better name idea...suggestions welcome.
* Changes to the base button styles to match the button style for the new designs.