### PR TITLE
Type tweaks - remove XM font size

### DIFF
--- a/src/styles/base/_typography-mixins.scss
+++ b/src/styles/base/_typography-mixins.scss
@@ -34,6 +34,7 @@
 	letter-spacing: 0;
 }
 
+// 50px (desktop)
 @mixin text-xxl {
 	font-size:  1.555555556rem;
 	line-height: $base-line-height-sm * 1.5;
@@ -44,6 +45,7 @@
 	}
 }
 
+// 32px (desktop)
 @mixin text-xl {
 	font-size:  1.333333333rem;
 	line-height: $base-line-height-sm * 1.25;
@@ -54,19 +56,17 @@
 	}
 }
 
+// 28
 @mixin text-lg {
-	font-size: 1.333333333rem;
-	line-height: $base-line-height * 1.5;
+	font-size: 1.555555556rem;
+	line-height: $base-line-height * 1.29;
 }
 
-@mixin text-xm {
-	font-size: 1.222222222rem;
-	line-height: $base-line-height * 1.25;
-}
 
+// 22
 @mixin text-md {
-	font-size: 1.111111111rem;
-	line-height: $base-line-height * 1.25;
+	font-size: 1.222222222rem;
+	line-height: $base-line-height;
 }
 
 @mixin text-std {

--- a/src/styles/components/_Buttons.scss
+++ b/src/styles/components/_Buttons.scss
@@ -1,6 +1,6 @@
 .Btn {
 	@include font-body;
-	@include text-xm;
+	@include text-md;
 	border: 1px solid $color-link;
 	border-radius: 4px;
 	padding: #{ $gutter-width / 4 } $gutter-width;


### PR DESCRIPTION
I was working on https://github.com/humanmade/Human-Made-Website-Theme/issues/154 and I think barbara has consolidated some of the font sizes across the site. I don't think we need both `md` and `xm` sizes, so I consolidated and tweaked the `md` and `lg` font size to match the site.  

Large text is used by section headings (important copy block) and the md text is used by things like case study titles on the what we do page and category nav in the blog.