### PR TITLE
Also remove clip-path on focus

### DIFF
--- a/src/styles/base/_typography.scss
+++ b/src/styles/base/_typography.scss
@@ -149,6 +149,7 @@ a {
 // Display text on focus (for skip links).
 .screen-reader-text:focus {
 	clip: auto;
+	clip-path: none;
 	display: block;
 	left: 0.5em;
 	top: 0.5em;


### PR DESCRIPTION
On focus the skip link did not show up.
Clip-path also needed to be disabled.