### PR TITLE
Add missing focus and/or hover styles

### DIFF
--- a/src/styles/components/_hm-logo.scss
+++ b/src/styles/components/_hm-logo.scss
@@ -8,8 +8,13 @@
 	width: 156px;
 	height: 30px;
 	margin: $margin-vertical-sm $gutter-width;
-	display: inline-block;
 	vertical-align: top;
+	opacity: 1.0;
+
+	&:hover,
+	&:focus {
+		opacity: 0.6;
+	}
 }
 
 .hm-logo--red {


### PR DESCRIPTION
link on hm-logo
- add shover/focus style on link hm-logo
- removes double display: inline-block declaration on .hm-logo

Related to https://github.com/humanmade/Human-Made-Website-Theme/issues/295