### PR TITLE
#138 fixes label count decentralized

### DIFF
--- a/src/styles/components/_labels.scss
+++ b/src/styles/components/_labels.scss
@@ -40,9 +40,10 @@
 	border-radius: 100%;
 	min-width: $base-font-size;
 	height: $base-font-size;
-	line-height: $base-font-size;
+	line-height: 1 + $base-font-size;
 	font-family: $font-family-code;
 	font-size: .6 * $base-font-size;
+	vertical-align: middle;
 	background: $color-primary;
 	color: $color-white;
 	margin-left: 0.1em;


### PR DESCRIPTION
I've added "vertical-align:middle" to "label__count" that made it looks good, but had a problem yet, font was 1px to top, I tested a lot of fonts and only "consolas" have this behavior, so I summed 1 + $base-font-size (which is 18px in this case) and solved the issue.

I don't know if adding it + 1 to the base font size is the better solution, but is what I've found until now.

(Sorry for the terrible english, I'm improving it)

REF: #138 