### PR TITLE
Update hm-red to match guidelines

### DIFF
--- a/gulp/gulp-svg.js
+++ b/gulp/gulp-svg.js
@@ -53,14 +53,14 @@ var registerTask = function( taskId, color ) {
 var iconColors = [
 	{ name: 'black', fill: '#353535' },
 	{ name: 'white', fill: '#FFFFFF' },
-	{ name: 'red',   fill: '#D14732' },
+	{ name: 'red',   fill: '#D24632' },
 	{ name: 'blue',  fill: '#7DC9DA' },
 ];
 
 var logoColors = [
 	{ name: 'black', fill: '#353535' },
 	{ name: 'white', fill: '#FFFFFF' },
-	{ name: 'red',   fill: '#D14732' },
+	{ name: 'red',   fill: '#D24632' },
 ];
 
 // Register tasks for each icon color and logo colors.

--- a/src/styles/_brand-colors.scss
+++ b/src/styles/_brand-colors.scss
@@ -1,5 +1,5 @@
 // Brand Colours.
-$hm-red:         #D14732;
+$hm-red:         #D24632;
 $hm-blue:        #7DC9DA;
 $hm-warm-grey:   #504C4C;
 $hm-dark-grey:   #353535;


### PR DESCRIPTION
[In this ticket](https://github.com/humanmade/Human-Made-Website-Theme/issues/325) we agreed upon #D14732 for the shade of red that meets accessibility requirements.

However it is listed as a slightly different shade here: https://drive.google.com/file/d/0B2okjXCGXwo2Nk1scUtzM2VZRlk/view

Visually - difference in the shade of red is almost impossible to see... but I'd like to be consistent! - @grarighe shall I updated the web pattern library to match? 

