### PR TITLE
Push to S3 and add npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,5 +25,9 @@
     "require-dir": "^0.3.0",
     "sass-lint": "^1.10.2"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "scripts": {
+    "build": "gulp",
+    "deploy": "npm run build && aws s3 sync ./dist/assets s3://make.hmn.md/pattern-library --acl public-read"
+  }
 }

--- a/src/html/pages/instructions.html
+++ b/src/html/pages/instructions.html
@@ -11,6 +11,10 @@
 
 <pre><code class="language-html">&lt;link rel=&quot;stylesheet&quot; href=&quot;hm-pattern-library/assets/styles/juniper.css&quot; /&gt;</code></pre>
 
+You can also use the CDN directly:
+
+<pre><code class="language-html">&lt;link rel=&quot;stylesheet&quot; href=&quot;http://make.hmn.md/pattern-library/styles/juniper.css&quot; /&gt;</code></pre>
+
 <h3>Juniper SASS.</h3>
 
 <p>For more complex projects, you can include the SCSS files at the top of your SCSS file. You will need to define the project path so that images load correctly. See the example SCSS file below.</p>


### PR DESCRIPTION
This adds `npm run build` and `npm run deploy`, the latter of which deploys the `assets` build directory to S3 at http://make.hmn.md/pattern-library (e.g. `http://make.hmn.md/pattern-library/styles/juniper.css`)

These aren't running through CloudFront as far as I know (@joehoyle?), plus it doesn't support HTTPS, so not really useful for production. Useful when you're just hacking around though.