### PR TITLE
Automate building master and deploying gh-pages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,41 @@
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/node:9-stretch
+
+    branches:
+      only:
+        # Whitelist branches to build for.
+        - master
+        - build-test
+    steps:
+      # Checkout repo & subs:
+      - checkout
+      - run: git submodule sync
+      - run: git submodule update --init
+
+      # Get npm cache:
+      - restore_cache:
+          key: npm
+
+      # Build steps:
+      - run: npm install
+      - run: npm run build
+
+      # Make fast:
+      - save_cache:
+          key: npm
+          paths:
+            - ~/.npm
+
+      # Run the default deploy:
+      - deploy:
+          command: .circleci/deploy.sh
+
+      # Run the gh-pages deploy:
+      - deploy:
+          environment:
+            DEPLOY_BRANCH: gh-pages-test
+            SRC_PATH: /dist
+          command: .circleci/deploy.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,6 +28,7 @@ jobs:
           key: npm
           paths:
             - ~/.npm
+            - ~/.node-gyp
 
       # Run the default deploy:
       - deploy:
@@ -37,5 +38,5 @@ jobs:
       - deploy:
           environment:
             DEPLOY_BRANCH: gh-pages-test
-            SRC_PATH: /dist
+            SRC_PATH: /dist/
           command: .circleci/deploy.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,6 @@ jobs:
       # Run the gh-pages deploy:
       - deploy:
           environment:
-            DEPLOY_BRANCH: gh-pages-test
+            DEPLOY_BRANCH: gh-pages
             SRC_PATH: /dist/
           command: .circleci/deploy.sh

--- a/.circleci/deploy-exclude.txt
+++ b/.circleci/deploy-exclude.txt
@@ -1,0 +1,11 @@
+# Add files or patterns to exclude from the built branch here.
+# Consult the "INCLUDE/EXCLUDE PATTERN RULES" section of the rsync manual for
+# supported patterns.
+#
+# Note: Excluding ".circleci" will cause your branch to fail. Use the
+# `branches` option in config.yml instead.
+
+.git
+.gitignore
+node_modules
+.sass-cache

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -1,0 +1,82 @@
+#!/bin/bash -e
+#
+# Deploy your branch.
+#
+
+DEPLOY_SUFFIX="${DEPLOY_SUFFIX:--built}"
+GIT_USER="${DEPLOY_GIT_USER:-CircleCI}"
+GIT_EMAIL="${DEPLOY_GIT_EMAIL:-ryan+travis@hmn.md}"
+
+BRANCH="${CIRCLE_BRANCH}"
+SRC_DIR="$PWD"
+SRC_PATH="/"
+
+if [[ -z "$BRANCH" ]]; then
+	echo "No branch specified!"
+	exit 1
+fi
+
+DEPLOY_BRANCH=${DEPLOY_BRANCH:-$BRANCH$DEPLOY_SUFFIX}
+BUILD_DIR="/tmp/hm-build-${DEPLOY_BRANCH}"
+
+if [[ -d "$BUILD_DIR" ]]; then
+	echo "WARNING: ${BUILD_DIR} already exists. You may have accidentally cached this"
+	echo "directory. This will cause issues with deploying."
+	exit 1
+fi
+
+COMMIT=$(git rev-parse HEAD)
+
+echo "Deploying $BRANCH to $DEPLOY_BRANCH"
+
+# If the deploy branch doesn't already exist, create it from the empty root.
+if ! git rev-parse --verify "remotes/origin/$DEPLOY_BRANCH" >/dev/null 2>&1; then
+	echo -e "\nCreating $DEPLOY_BRANCH..."
+	git worktree add --detach "$BUILD_DIR"
+	cd "$BUILD_DIR"
+	git checkout --orphan "$DEPLOY_BRANCH"
+else
+	echo "Using existing $DEPLOY_BRANCH"
+	git worktree add --detach "$BUILD_DIR" "remotes/origin/$DEPLOY_BRANCH"
+	cd "$BUILD_DIR"
+	git checkout "$DEPLOY_BRANCH"
+fi
+
+# Ensure we're in the right dir
+cd "$BUILD_DIR"
+
+# Remove existing files
+git rm -rfq .
+
+# Sync built files
+echo -e "\nSyncing files..."
+if ! command -v 'rsync'; then
+	sudo apt-get install -q -y rsync
+fi
+
+rsync -av "$SRC_DIR$SRC_PATH" "$BUILD_DIR" --exclude-from "$SRC_DIR/.circleci/deploy-exclude.txt"
+
+# Add changed files
+git add .
+
+if [ -z "$(git status --porcelain)" ]; then
+	echo "No changes to built files."
+	exit
+fi
+
+# Print status!
+echo -e "\nSynced files. Changed:"
+git status -s
+
+# Double-check our user/email config
+if ! git config user.email; then
+	git config user.name "$GIT_USER"
+	git config user.email "$GIT_EMAIL"
+fi
+
+# Commit it.
+MESSAGE=$( printf 'Build changes from %s\n\n%s' "${COMMIT}" "${CIRCLE_BUILD_URL}" )
+git commit -m "$MESSAGE"
+
+# Push it (real good).
+git push origin "$DEPLOY_BRANCH"

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -9,7 +9,7 @@ GIT_EMAIL="${DEPLOY_GIT_EMAIL:-ryan+travis@hmn.md}"
 
 BRANCH="${CIRCLE_BRANCH}"
 SRC_DIR="$PWD"
-SRC_PATH="/"
+SRC_PATH="${SRC_PATH:-/}"
 
 if [[ -z "$BRANCH" ]]; then
 	echo "No branch specified!"

--- a/package.json
+++ b/package.json
@@ -25,5 +25,8 @@
     "require-dir": "^0.3.0",
     "sass-lint": "^1.10.2"
   },
-  "dependencies": {}
+  "scripts": {
+    "gulp": "gulp",
+    "build": "gulp build"
+  }
 }


### PR DESCRIPTION
This will build the pattern library on circleci and do the following:

1. Push entire built project to `master-built` branch on merge to master
2. Push contents of `/dist/` to the `gh-pages` branch on merge to master

We could remove the `master-built` bit if you don't think it's needed but it could be handy for situations down the line, say if we add a react component library to this repo.