### PR TITLE
Larger size cta link

### DIFF
--- a/src/html/components/cta.html
+++ b/src/html/components/cta.html
@@ -1,0 +1,13 @@
+<h3 id="style-guide-forms-buttons" class="style-guide-title">Call to action links</h3>
+
+<p><a class="cta" href="#">Link cta</a></p>
+
+<p><a class="cta cta--arrow" href="#">Link arrow</a></p>
+
+<p><a class="cta cta--arrow-left" href="#">Link arrow-left</a></p>
+
+<p><a class="cta cta--small cta--arrow" href="#">Link small with arrow</a></p>
+
+<p><a class="cta cta--large cta--arrow" href="#">Link large with arrow</a></p>
+
+

--- a/src/html/pages/components.html
+++ b/src/html/pages/components.html
@@ -6,5 +6,6 @@
 @include( './../components/labels.html' )  
 @include( './../components/code-block.html' )
 @include( './../components/loading-indicators.html' )
+@include( './../components/cta.html' )
 
 @include( './../parts/footer.html', { "js_file": "./../assets/js/juniper.min.js" } )  ;

--- a/src/styles/base/_typography-mixins.scss
+++ b/src/styles/base/_typography-mixins.scss
@@ -62,6 +62,11 @@
 	line-height: $base-line-height * 1.29;
 }
 
+// 24
+@mixin text-ml {
+	font-size: 1.3333333332rem;
+	line-height: $base-line-height;
+}
 
 // 22
 @mixin text-md {

--- a/src/styles/components/_cta.scss
+++ b/src/styles/components/_cta.scss
@@ -8,6 +8,10 @@
 		@include text-std;
 	}
 
+	&--large {
+		@include text-ml;
+	}
+
 	&--arrow {
 		transition: margin-left 0.2s ease-in-out, border-color 0.2s ease-in-out;
 		margin-right: calc( 1.5rem + #{ $gutter-width / 2 } );
@@ -80,3 +84,5 @@
 		}
 	}
 }
+
+


### PR DESCRIPTION
Added a 24 pixel size link, for the CTAs with a grey background. Then they also comply with WCAG 2 AA (ratio 3.1 for larger text).
Discussed this with @grarighe 

This will be used on the HM site homepage with the "Join our team" link