### PR TITLE
No uppercase titles h2-h6

### DIFF
--- a/src/styles/base/_images.scss
+++ b/src/styles/base/_images.scss
@@ -2,3 +2,7 @@ img {
 	max-width: 100%;
 	height: auto;
 }
+
+figure {
+	margin: 0;
+}

--- a/src/styles/base/_typography-mixins.scss
+++ b/src/styles/base/_typography-mixins.scss
@@ -1,8 +1,6 @@
 @mixin font-heading {
 	font-family: $font-family-heading;
 	font-weight: 700;
-	text-transform: uppercase;
-	letter-spacing: 0.01em;
 
 	em,
 	i,
@@ -31,7 +29,11 @@
 	font-family: $font-family-accent;
 	font-weight: 500;
 	text-transform: uppercase;
-	letter-spacing: 0;
+}
+
+@mixin font-caps {
+	text-transform: uppercase;
+	letter-spacing: 0.01em;
 }
 
 // 50px (desktop)

--- a/src/styles/base/_typography.scss
+++ b/src/styles/base/_typography.scss
@@ -28,7 +28,7 @@ h1,
 .text-xxl {
 	@include text-xxl;
 	@include font-heading;
-	text-transform: uppercase;
+	@include font-caps;
 	margin: $margin-vertical-sm 0;
 	color: $color-text-heading;
 }
@@ -39,11 +39,6 @@ h2,
 	@include font-heading;
 	margin: $margin-vertical-sm 0;
 	color: $color-text-heading;
-
-
-	@media #{ $mq-sm-down } {
-		text-transform: uppercase;
-	}
 }
 
 h3,


### PR DESCRIPTION
For a few reasons, it is not desirable to have headings on headings by default.

* Accessibility concerns.
* The H2 project - found them too heavy and not very readable.
* Blog posts about brands/technical writing - hard to capitalize correctly.

This keeps the caps around for the H1 tag though. 