### PR TITLE
Update typography styles. 

### DIFF
--- a/src/html/components/code-block.html
+++ b/src/html/components/code-block.html
@@ -1,10 +1,27 @@
 <h3 id="style-guide-components-code" class="style-guide-title">Code blocks</h3>
 
+<pre><code>{
+	"name": "Tom",
+	"age": "12",
+	"location": "USA",
+}</code></pre>
+
+<p>Add a class like <code>language-php</code> for syntax highlighting powered by <a href="https://prismjs.com/">Prism.js</a>.</p>
+
+<p>Note that Prism forces you to use the correct element for marking up code: <code>&lt;code&gt;</code>. On its own for inline code, or inside a <code>&lt;pre&gt;</code> for blocks of code. See example below.</p>
+
+<pre><code class="language-html">&lt;pre&gt;&lt;code class=&quot;language-html&quot;&gt;
+	// Sample code...
+&lt;/code&gt;&lt;/pre&gt;</code></pre>
+
+<p>Prism supports HTML, PHP, JS, CSS, SCSS and <a href="https://prismjs.com/#supported-languages">many other languages.</a></p>
+
 <pre><code class="language-php">&lt;?php
+if ( 'pens' === pencils ) {
+	return false;
+}</code></pre>
 
-	if ( 'pens' === pencils ) {
-		return false;
-	}</code></pre>
-
-
-<p>This is some inline code demonstrating how to open a php file <code class="language-php">&lt;?php</code></p>
+<pre><code class="language-css">.my-component {
+	color: #FF0000;
+	font-family: "Comic Sans MS", "Comic Sans", cursive;
+}</code></pre>

--- a/src/html/components/hr.html
+++ b/src/html/components/hr.html
@@ -1,0 +1,2 @@
+<h3 id="style-guide-base-hr" class="style-guide-title">Horizontal Rule</h3>
+<hr />

--- a/src/html/components/lists.html
+++ b/src/html/components/lists.html
@@ -3,6 +3,14 @@
 <ul>
 	<li>Pellentesque eu est a nulla placerat dignissim.</li>
 	<li>Etiam scelerisque, nunc ac egestas consequat, odio nibh euismod nulla, eget auctor orci nibh vel nisi. Morbi a enim in magna semper bibendum.</li>
+	<li>Lectus viverra dui amet maximus natoque auctor.
+		<ul>
+			<li>Aliquam erat volutpat.</li>
+			<li>Mauris vel neque sit amet nunc gravida congue sed sit amet purus.</li>
+			<li>Quisque lacus quam, egestas ac tincidunt a, lacinia vel velit.</li>
+		</ul>
+	</li>
+	<li>Blandit tellus varius nascetur urna euismod commodo posuere mollis imperdiet metus torquent praesent proin rutrum finibus viverra in etiam lectus nibh ipsum et elementum habitasse malesuada morbi tristique magna fusce nunc luctus lacus vel accumsan.</li>
 </ul>
 
 <ol>

--- a/src/html/pages/base.html
+++ b/src/html/pages/base.html
@@ -9,5 +9,7 @@
 @include( './../components/lists.html' )
 @include( './../components/table.html' )
 @include( './../components/headings.html' )
+@include( './../components/hr.html' )
+
 
 @include( './../parts/footer.html', { "js_file": "./../assets/js/juniper.min.js" } )

--- a/src/styles/base/_typography-mixins.scss
+++ b/src/styles/base/_typography-mixins.scss
@@ -25,6 +25,10 @@
 	}
 }
 
+@mixin font-code {
+	font-family: $font-family-code;
+}
+
 @mixin font-accent {
 	font-family: $font-family-accent;
 	font-weight: 500;

--- a/src/styles/base/_typography.scss
+++ b/src/styles/base/_typography.scss
@@ -85,7 +85,7 @@ ul,
 ol {
 	list-style-position: outside;
 	padding: 0;
-	padding: 0 0 0 $gutter-width;
+	padding: 0 0 0 $gutter-width * 2;
 
 	ul,
 	ol {

--- a/src/styles/base/_typography.scss
+++ b/src/styles/base/_typography.scss
@@ -29,7 +29,7 @@ h1,
 	@include text-xxl;
 	@include font-heading;
 	@include font-caps;
-	margin: $margin-vertical-sm 0;
+	margin: $margin-vertical-sm 0 $margin-vertical-sm * 0.5;
 	color: $color-text-heading;
 }
 
@@ -37,7 +37,7 @@ h2,
 .text-xl {
 	@include text-xl;
 	@include font-heading;
-	margin: $margin-vertical-sm 0;
+	margin: $margin-vertical-sm 0 $margin-vertical-sm * 0.5;
 	color: $color-text-heading;
 }
 
@@ -45,7 +45,7 @@ h3,
 .text-lg {
 	@include text-lg;
 	@include font-heading;
-	margin: $margin-vertical-sm 0;
+	margin: $margin-vertical-sm 0 $margin-vertical-sm * 0.5;
 	color: $color-text-heading;
 }
 
@@ -53,7 +53,7 @@ h4,
 .text-md {
 	@include text-md;
 	@include font-heading;
-	margin: $margin-vertical-sm 0;
+	margin: $margin-vertical-sm 0 $margin-vertical-sm * 0.5;
 	color: $color-text-default;
 }
 
@@ -61,7 +61,7 @@ h5,
 h6 {
 	@include text-std;
 	@include font-heading;
-	margin: $margin-vertical-sm 0;
+	margin: $margin-vertical-sm 0 $margin-vertical-sm * 0.5;
 	color: $color-text-heading;
 }
 
@@ -69,7 +69,7 @@ p,
 ul,
 ol,
 .text-std {
-	margin: $margin-vertical-sm 0;
+	margin: $margin-vertical-sm * 0.5 0;
 }
 
 small,
@@ -95,17 +95,17 @@ ol {
 
 blockquote {
 	@include text-lg;
-	margin: $margin-vertical-sm 0;
+	margin: $margin-vertical-sm * 0.5 0;
 
 	@media #{ $mq-sm-up } {
-		margin: $margin-vertical-lg 0;
+		margin: $margin-vertical-sm 0;
 	}
 }
 
 hr {
 	border: 1px solid $border-color;
 	border-width: 1px 0 0 0;
-	margin: $margin-vertical-lg 0;
+	margin: $margin-vertical-sm 0;
 }
 
 code,

--- a/src/styles/base/_typography.scss
+++ b/src/styles/base/_typography.scss
@@ -111,6 +111,7 @@ hr {
 code,
 pre {
 	@include text-xs;
+	@include font-code;
 	color: $color-text-pre;
 	background: $color-background-pre;
 	padding: 0px 5px;
@@ -119,16 +120,16 @@ pre {
 }
 
 pre {
-	padding: #{ $margin-vertical-sm * 0.5 } #{ $gutter-width * 0.5 };
+	padding: #{ $margin-vertical-sm * 0.5 } #{ $gutter-width };
 	display: block;
 	margin: $margin-vertical-sm 0;
 	max-width: 100%;
 	overflow: auto;
 	white-space: pre-wrap;
+	tab-size: 4;
 }
 
 code {
-	@include text-sm;
 	line-height: inherit;
 }
 

--- a/src/styles/style-guide.scss
+++ b/src/styles/style-guide.scss
@@ -68,7 +68,7 @@
 }
 
 .pattern-library-subtitle {
-	margin-top: $margin-vertical-sm * -1;
+	margin-top: $margin-vertical-sm * -0.5;
 	margin-bottom: $margin-vertical-sm * 1;
 }
 


### PR DESCRIPTION
I'm looking at fixing a few style issues in the Engineering Handbook, where Ryan has overridden some of the pattern library styles. I think he was trying to tighten the text styles up a bit, reducing some excess margins etc. to improve legibility.

* Reduce margins between paragraphs. 
* Reduce bottom margin on headings. 
* Improve list styles
* Add hr styles
* Reduce blockquote margins.
* Improve code text styles. Apply font-family and other styles to non prism code blocks. 