### PR TITLE
Adjust link border defaults to prevent page reflow

### DIFF
--- a/src/styles/base/_typography-mixins.scss
+++ b/src/styles/base/_typography-mixins.scss
@@ -112,9 +112,9 @@
 
 @mixin text-link {
 	color: $color-link;
-	border-bottom: 1px solid $color-link;
+	border-bottom: 1px solid desaturate( lighten( $color-link, 20% ), 10 );
 	text-decoration: none;
-	transition: color .2s ease-in, background .2s ease-in, border-width .2s ease-in;
+	transition: color .2s ease-in, background .2s ease-in;
 
 	&:link,
 	&:visited {
@@ -125,12 +125,12 @@
 	&:hover,
 	&:focus {
 		color: $color-link-hover;
-		transition: color .2s ease-out, background .2s ease-out, border-width .2s ease-out;
-		border-bottom: 2px solid $color-link;
+		transition: color .2s ease-out, background .2s ease-out;
+		border-bottom: 1px solid currentColor;
 	}
 
 	&:focus {
-		outline: none;
+		outline-offset: 0.25rem;
 	}
 }
 


### PR DESCRIPTION
Using borders for underlining is already bad, but using a variable-width border causes all kinds of layout pain. Hovering a link should not cause the entire subsequent page to reflow.

Also restores outline on focused link for accessibility